### PR TITLE
feat: 쇼츠 피드 커서 기반 페이지네이션 구현

### DIFF
--- a/src/main/java/com/trip/tripshorts/video/controller/VideoController.java
+++ b/src/main/java/com/trip/tripshorts/video/controller/VideoController.java
@@ -1,9 +1,8 @@
 package com.trip.tripshorts.video.controller;
 
-import com.trip.tripshorts.video.dto.VideoCreateRequest;
-import com.trip.tripshorts.video.dto.VideoCreateResponse;
-import com.trip.tripshorts.video.dto.VideoInfoResponse;
-import com.trip.tripshorts.video.dto.VideoListResponse;
+import com.trip.tripshorts.auth.service.AuthService;
+import com.trip.tripshorts.member.domain.Member;
+import com.trip.tripshorts.video.dto.*;
 import com.trip.tripshorts.video.service.VideoService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,6 +20,7 @@ import java.util.Map;
 public class VideoController {
 
     private final VideoService videoService;
+    private final AuthService authService;
 
     @GetMapping("/presigned-url")
     public ResponseEntity<Map<String, String>> getPresignedUrl(
@@ -49,4 +49,14 @@ public class VideoController {
     public ResponseEntity<VideoInfoResponse> getVideoInfo(@RequestParam("videoId") Long videoId) {
         return ResponseEntity.ok(videoService.getVideoInfo(videoId));
     }
+
+    @GetMapping("/feed")
+    public ResponseEntity<VideoPageResponse> getVideoPages(
+            @RequestParam(required = false) Long cursorId,
+            @RequestParam int size
+    ){
+        log.info("pagination controller in");
+        return ResponseEntity.ok(videoService.getVideoPage(cursorId, size));
+    }
+
 }

--- a/src/main/java/com/trip/tripshorts/video/dto/VideoCreatorDto.java
+++ b/src/main/java/com/trip/tripshorts/video/dto/VideoCreatorDto.java
@@ -1,0 +1,21 @@
+package com.trip.tripshorts.video.dto;
+
+import com.trip.tripshorts.member.domain.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class VideoCreatorDto {
+    private Long id;
+    private String nickname;
+    private String imageUrl;
+
+    public static VideoCreatorDto from(Member member){
+        return VideoCreatorDto.builder()
+                .id(member.getId())
+                .nickname(member.getNickname())
+                .imageUrl(member.getImageUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/trip/tripshorts/video/dto/VideoPageResponse.java
+++ b/src/main/java/com/trip/tripshorts/video/dto/VideoPageResponse.java
@@ -1,0 +1,22 @@
+package com.trip.tripshorts.video.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class VideoPageResponse {
+    private final List<VideoResponse> videos;
+    private final Long nextCursor;
+    private final boolean hasNext;
+
+    public static VideoPageResponse of(List<VideoResponse> videos, Long lastVideoId, boolean hasNext) {
+        return VideoPageResponse.builder()
+                .videos(videos)
+                .nextCursor(hasNext ? lastVideoId : null)
+                .hasNext(hasNext)
+                .build();
+    }
+}

--- a/src/main/java/com/trip/tripshorts/video/dto/VideoResponse.java
+++ b/src/main/java/com/trip/tripshorts/video/dto/VideoResponse.java
@@ -1,0 +1,36 @@
+package com.trip.tripshorts.video.dto;
+
+import com.trip.tripshorts.member.domain.Member;
+import com.trip.tripshorts.tour.domain.Tour;
+import com.trip.tripshorts.video.domain.Video;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class VideoResponse {
+    private Long id;
+    private String videoUrl;
+    private String thumbnailUrl;
+    private VideoCreatorDto creator;
+    private int likeCount;
+    private int commentCount;
+    private LocalDateTime createdAt;
+    private boolean liked;
+
+    public static VideoResponse from(Video video, Member currentMember) {
+        return VideoResponse.builder()
+                .id(video.getId())
+                .videoUrl(video.getVideoUrl())
+                .thumbnailUrl(video.getThumbnailUrl())
+                .creator(VideoCreatorDto.from(video.getMember()))
+                .likeCount(video.getLikes().size())
+                .commentCount(video.getComments().size())
+                .createdAt(video.getCreatedDate())
+                .liked(video.getLikes().stream()
+                        .anyMatch(like -> like.getMember().getId().equals(currentMember.getId())))
+                .build();
+    }
+}

--- a/src/main/java/com/trip/tripshorts/video/repository/VideoRepository.java
+++ b/src/main/java/com/trip/tripshorts/video/repository/VideoRepository.java
@@ -6,6 +6,7 @@ import com.trip.tripshorts.video.dto.VideoListResponse;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.security.core.parameters.P;
 
 import java.util.List;
 import java.util.Optional;
@@ -22,4 +23,11 @@ public interface VideoRepository extends JpaRepository<Video, Long> {
             "JOIN v.tour t " +
             "WHERE v.id = :videoId")
     Optional<Tour> findTourByVideoId(@Param("videoId") Long videoId);
+
+    @Query("SELECT DISTINCT v FROM Video v " +
+            "LEFT JOIN FETCH v.member m " +  // N+1 방지
+            "WHERE (:cursorId IS NULL OR v.id < :cursorId) " +
+            "ORDER BY v.id DESC " +
+            "LIMIT :size")
+    List<Video> findVideosByCursorId(@Param("cursorId") Long cursorId, @Param("size") int size);
 }


### PR DESCRIPTION
## 📌 구현 기능
- 쇼츠 피드의 무한 스크롤을 위한 커서 기반 페이지네이션 기능 구현

## 🔍 구현 내용
- VideoRepository에 커서 기반 페이징 쿼리 추가
- 페이징 처리를 위한 DTO 구현
  - VideoPageResponse : 페이징 정보(videos, nextCursor, hasNext)를 포함
- VideoResponse
  - 비디오 정보와 해당 비디오를 만든 사람 정보를 포함
- VideoCreatorDto
  - 비디오를 만든 사람 정보를 클래스 분리  
- VideoController에 페이징 엔드포인트 추가
  - cursorId와 size를 파라미터로 받아 처리
  - 현재 로그인한 사용자 정보도 함께 처리
  
## 🤔 고민한 부분
- Repository에 findVideosByCursorId 구현 시 N+1문제가 발생하였습니다. 처음에는 N+1이라는 것을 몰라 원인을 찾다 N+1문제에 대해 알게 되었습니다. 
  - LEFT JOIN FETCH를 사용하여 해결(참고 항목에 관련 블로그 올려놓았습니다.)  
- 무한 스크롤 구현 시 다음 페이지 존재 여부 확인하는 방법으로 쿼리 한 번에 해결하는 편이 좋다고 판단하여 size+1개를 조회하여 다음 페이지 존재 여부를 확인하는 방법을 사용하였습니다.  
- 추후 프론트엔드에서 구별이 필요할 거라고 생각하여 현재 사용자가 본 영상에 좋아요를 누른 사용자인지 확인하여 boolean liked 필드를 응답에 담는 로직을 추가하였습니다.
 
## ✅ 테스트 결과
- Postman을 통한 API 테스트
  - 첫 페이지 요청 : 정상 작동
  - 커서 기반 다음 페이지 요청 : 정상 작동
  - 마지막 페이지에서 hasNext가 false로 정상 반환 

- local 환경에서 vuejs FE와 연결 테스트 결과 모든 기능 정상 작동

## 📌 참고
[JPA N+1 문제와 해결법 총정리](https://velog.io/@xogml951/JPA-N1-%EB%AC%B8%EC%A0%9C-%ED%95%B4%EA%B2%B0-%EC%B4%9D%EC%A0%95%EB%A6%AC#4-%EA%B2%B0%EB%A1%A0)