### PR TITLE
feat: 동영상 업로드 시 관광지 선택을 위한 기능 구현

### DIFF
--- a/src/main/java/com/trip/tripshorts/tour/controller/TourController.java
+++ b/src/main/java/com/trip/tripshorts/tour/controller/TourController.java
@@ -1,0 +1,42 @@
+package com.trip.tripshorts.tour.controller;
+
+import com.trip.tripshorts.tour.dto.TourResponse;
+import com.trip.tripshorts.tour.service.TourService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/tour")
+public class TourController {
+
+    private final TourService tourService;
+
+    @GetMapping("/areas")
+    public ResponseEntity<List<String>> getAreaNames() {
+        List<String> areas = tourService.getDistinctAreaNames();
+        return ResponseEntity.ok(areas);
+    }
+
+    @GetMapping("/districts")
+    public ResponseEntity<List<String>> getDistrictNames(@RequestParam String areaName) {
+        List<String> districts = tourService.getDistrictsByArea(areaName);
+        return ResponseEntity.ok(districts);
+    }
+
+    @GetMapping("/attractions")
+    public ResponseEntity<List<TourResponse>> getAttractionsByDistrict(
+            @RequestParam String areaName,
+            @RequestParam String districtName) {
+        List<TourResponse> tourInfos = tourService.getAttractionsByDistrict(areaName, districtName);
+        return ResponseEntity.ok(tourInfos);
+    }
+
+
+}

--- a/src/main/java/com/trip/tripshorts/tour/dto/TourResponse.java
+++ b/src/main/java/com/trip/tripshorts/tour/dto/TourResponse.java
@@ -1,0 +1,32 @@
+package com.trip.tripshorts.tour.dto;
+
+import com.trip.tripshorts.tour.domain.Tour;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class TourResponse {
+    private Long tourId;
+    private String title;
+    private String address;
+    private double lat;
+    private double lng;
+    private String areaName;
+    private String districtName;
+
+    public static TourResponse from(Tour tour) {
+        return TourResponse.builder()
+                .tourId(tour.getId())
+                .title(tour.getTitle())
+                .address(tour.getAddress())
+                .lat(tour.getLat())
+                .lng(tour.getLng())
+                .areaName(tour.getAreaName())
+                .districtName(tour.getDistrictName())
+                .build();
+    }
+}

--- a/src/main/java/com/trip/tripshorts/tour/repository/TourRepository.java
+++ b/src/main/java/com/trip/tripshorts/tour/repository/TourRepository.java
@@ -1,0 +1,21 @@
+package com.trip.tripshorts.tour.repository;
+
+import com.trip.tripshorts.tour.domain.Tour;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface TourRepository extends JpaRepository<Tour, Long> {
+    @Query("SELECT DISTINCT t.areaName FROM Tour t ORDER BY t.areaName")
+    List<String> findDistinctAreaNames();
+
+    @Query("SELECT DISTINCT t.districtName FROM Tour t WHERE t.areaName = :areaName ORDER BY t.districtName")
+    List<String> findDistinctDistrictNamesByAreaName(@Param("areaName") String areaName);
+
+    List<Tour> findAllByAreaNameAndDistrictName(String areaName, String districtName);
+
+}

--- a/src/main/java/com/trip/tripshorts/tour/service/TourService.java
+++ b/src/main/java/com/trip/tripshorts/tour/service/TourService.java
@@ -1,0 +1,33 @@
+package com.trip.tripshorts.tour.service;
+
+import com.trip.tripshorts.tour.domain.Tour;
+import com.trip.tripshorts.tour.dto.TourResponse;
+import com.trip.tripshorts.tour.repository.TourRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TourService {
+
+    private final TourRepository tourRepository;
+
+    public List<String> getDistinctAreaNames() {
+        return tourRepository.findDistinctAreaNames();
+    }
+
+    public List<String> getDistrictsByArea(String areaName) {
+        return tourRepository.findDistinctDistrictNamesByAreaName(areaName);
+    }
+
+
+    public List<TourResponse> getAttractionsByDistrict(String areaName, String districtName) {
+        return tourRepository.findAllByAreaNameAndDistrictName(areaName, districtName)
+                .stream().map(TourResponse::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/trip/tripshorts/video/dto/VideoCreateRequest.java
+++ b/src/main/java/com/trip/tripshorts/video/dto/VideoCreateRequest.java
@@ -10,4 +10,5 @@ import lombok.NoArgsConstructor;
 public class VideoCreateRequest {
     private String videoUrl;
     private String thumbnailUrl;
+    private Long tourId;
 }

--- a/src/main/java/com/trip/tripshorts/video/service/VideoService.java
+++ b/src/main/java/com/trip/tripshorts/video/service/VideoService.java
@@ -4,6 +4,7 @@ import com.trip.tripshorts.auth.service.AuthService;
 import com.trip.tripshorts.member.domain.Member;
 import com.trip.tripshorts.member.repository.MemberRepository;
 import com.trip.tripshorts.tour.domain.Tour;
+import com.trip.tripshorts.tour.repository.TourRepository;
 import com.trip.tripshorts.video.domain.Video;
 import com.trip.tripshorts.video.dto.*;
 import com.trip.tripshorts.video.repository.VideoRepository;
@@ -24,6 +25,7 @@ public class VideoService {
     private final S3Service s3Service;
     private final MemberRepository memberRepository;
     private final AuthService authService;
+    private final TourRepository tourRepository;
 
     public String getPresignedUrlForUpload(String filename, String contentType) {
         return s3Service.generatePresignedUrlForUpload(filename, contentType);
@@ -32,11 +34,14 @@ public class VideoService {
     @Transactional
     public VideoCreateResponse createVideo(VideoCreateRequest videoCreateRequest) {
         Member member = authService.getCurrentMember();
+        Tour tour = tourRepository.findById(videoCreateRequest.getTourId())
+                .orElseThrow(()-> new EntityNotFoundException("해당 관광지를 찾을 수 없습니다."));
 
         Video video = Video.builder()
                 .videoUrl(videoCreateRequest.getVideoUrl())
                 .thumbnailUrl(videoCreateRequest.getThumbnailUrl())
                 .member(member)
+                .tour(tour)
                 .build();
 
         return VideoCreateResponse.from(videoRepository.save(video));


### PR DESCRIPTION
## 📌 구현 기능
동영상 업로드 시 관광지 선택을 위한 기능 구현

## 🔍 구현 내용
- TourController, TourService, TourRepository 구현
- TourResponse DTO 추가
- 지역별, 구역별 관광지 조회 API 추가
- VideoService에서 DB에 Video 정보 저장 시 Tour 정보를 활용하도록 로직 수정
- Frontend에서 받아오는 VideoCreateRequest에 tourId가 포함되도록 DTO 변경

## 🤔 고민한 부분
- 지역, 구역을 Response할 때, DTO로 따로 담을지 고민했으나 데이터의 크기가 크지 않고, 서비스 기간 동안 데이터의 변화가 없기 때문에 String List형식으로 담아서 반환하도록 하였습니다. 
- TourResponse DTO의 경우, Tour Entity와 1:1로 매핑되는 DTO로 변환 시 편리함과 안정성을 위해 DTO로 선언하였습니다.

## ✅ 테스트 결과
- 1번의 경우, tour 테이블과 연동되지 않는 업로드 시 DB 저장 형식입니다.(이전 메소드로 업로드 시)
- 2번, 3번의 경우, video 테이블은 tour_id를 통해 tour 테이블과 다대일 연결이 형성됩니다.
<img width="748" alt="image" src="https://github.com/user-attachments/assets/fc8a0643-0739-4d2e-9ba3-cb9a0b9f0fd1">

## 📌 참고
- 현재 관광지 선택 창에서 이름 순 정렬로 나오도록 되어있는데 좋아요 순이나 많은 사람들이 쇼츠로 등록한 장소부터 나오는 등의 기능 개선에 대해 고민해봐야 할 것 같습니다.