### PR TITLE
feat: 댓글 작성 및 댓글 목록 불러오기 기능 추가

### DIFF
--- a/src/main/java/com/trip/tripshorts/comment/controller/CommentController.java
+++ b/src/main/java/com/trip/tripshorts/comment/controller/CommentController.java
@@ -26,4 +26,10 @@ public class CommentController {
         List<CommentResponse> comments = commentService.getCommentList(videoId);
         return ResponseEntity.ok(comments);
     }
+
+    @PostMapping("/{videoId}/comment")
+    public ResponseEntity<Void> createComment(@PathVariable Long videoId, @RequestBody CommentRequest commentRequest){
+        commentService.createComment(videoId, commentRequest);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/trip/tripshorts/comment/controller/CommentController.java
+++ b/src/main/java/com/trip/tripshorts/comment/controller/CommentController.java
@@ -2,28 +2,28 @@ package com.trip.tripshorts.comment.controller;
 
 import com.trip.tripshorts.auth.domain.UserPrincipal;
 import com.trip.tripshorts.comment.dto.CommentRequest;
+import com.trip.tripshorts.comment.dto.CommentResponse;
 import com.trip.tripshorts.comment.service.CommentService;
 import com.trip.tripshorts.video.service.VideoService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
-@RequestMapping("/shorts")
+@RequestMapping("/api/v1/shorts")
 @RequiredArgsConstructor
+@Slf4j
 public class CommentController {
 
     private final CommentService commentService;
 
-    @PostMapping("/videoId")
-    public ResponseEntity<Void> saveComment(@RequestParam("videoId") Long videoId,
-                                            @RequestBody CommentRequest commentRequest,
-                                            @AuthenticationPrincipal UserPrincipal userInfo) {
-
-        commentService.saveComment(userInfo.getEmail(), videoId, commentRequest.content());
-
-        return ResponseEntity.ok().build();
-
+    @GetMapping("/{videoId}/comments")
+    public ResponseEntity<List<CommentResponse>> getCommentList(@PathVariable Long videoId){
+        List<CommentResponse> comments = commentService.getCommentList(videoId);
+        return ResponseEntity.ok(comments);
     }
 }

--- a/src/main/java/com/trip/tripshorts/comment/domain/Comment.java
+++ b/src/main/java/com/trip/tripshorts/comment/domain/Comment.java
@@ -1,15 +1,17 @@
 package com.trip.tripshorts.comment.domain;
 
 import com.trip.tripshorts.member.domain.Member;
+import com.trip.tripshorts.util.BaseTimeEntity;
 import com.trip.tripshorts.video.domain.Video;
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Getter
-@NoArgsConstructor
-public class Comment {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class Comment extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "comment_id")

--- a/src/main/java/com/trip/tripshorts/comment/dto/CommentResponse.java
+++ b/src/main/java/com/trip/tripshorts/comment/dto/CommentResponse.java
@@ -1,0 +1,24 @@
+package com.trip.tripshorts.comment.dto;
+
+import com.trip.tripshorts.comment.domain.Comment;
+import lombok.*;
+
+@Builder
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CommentResponse {
+    private Long id;
+    private String content;
+    private String nickname;
+    private String userProfileUrl;
+
+    public static CommentResponse from(Comment comment, String presignedUrl){
+        return CommentResponse.builder()
+                .id(comment.getId())
+                .content(comment.getContent())
+                .nickname(comment.getMember().getNickname())
+                .userProfileUrl(presignedUrl)
+                .build();
+    }
+
+}

--- a/src/main/java/com/trip/tripshorts/comment/dto/CommentResponse.java
+++ b/src/main/java/com/trip/tripshorts/comment/dto/CommentResponse.java
@@ -3,6 +3,8 @@ package com.trip.tripshorts.comment.dto;
 import com.trip.tripshorts.comment.domain.Comment;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Builder
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -11,13 +13,15 @@ public class CommentResponse {
     private String content;
     private String nickname;
     private String userProfileUrl;
+    private LocalDateTime createdAt;
 
-    public static CommentResponse from(Comment comment, String presignedUrl){
+    public static CommentResponse from(Comment comment){
         return CommentResponse.builder()
                 .id(comment.getId())
                 .content(comment.getContent())
                 .nickname(comment.getMember().getNickname())
-                .userProfileUrl(presignedUrl)
+                .userProfileUrl(comment.getMember().getImageUrl())
+                .createdAt(comment.getCreatedDate())
                 .build();
     }
 

--- a/src/main/java/com/trip/tripshorts/comment/repository/CommentRepository.java
+++ b/src/main/java/com/trip/tripshorts/comment/repository/CommentRepository.java
@@ -3,5 +3,8 @@ package com.trip.tripshorts.comment.repository;
 import com.trip.tripshorts.comment.domain.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findAllByVideoId(Long videoId);
 }

--- a/src/main/java/com/trip/tripshorts/comment/repository/CommentRepository.java
+++ b/src/main/java/com/trip/tripshorts/comment/repository/CommentRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-    List<Comment> findAllByVideoId(Long videoId);
+    List<Comment> findAllByVideoIdOrderByCreatedDateDesc(Long videoId);
 }

--- a/src/main/java/com/trip/tripshorts/comment/service/CommentService.java
+++ b/src/main/java/com/trip/tripshorts/comment/service/CommentService.java
@@ -42,12 +42,15 @@ public class CommentService {
         Member member = authService.getCurrentMember();
         Video video = videoRepository.findById(videoId)
                 .orElseThrow(()-> new EntityNotFoundException("Video not found"));
-
+        
         Comment comment = Comment.builder()
                 .content(commentRequest.content())
                 .video(video)
                 .member(member)
                 .build();
+
+        member.addComment(comment);
+        video.addComment(comment);
 
         commentRepository.save(comment);
     }

--- a/src/main/java/com/trip/tripshorts/comment/service/CommentService.java
+++ b/src/main/java/com/trip/tripshorts/comment/service/CommentService.java
@@ -1,37 +1,38 @@
 package com.trip.tripshorts.comment.service;
 
 import com.trip.tripshorts.comment.domain.Comment;
+import com.trip.tripshorts.comment.dto.CommentResponse;
 import com.trip.tripshorts.comment.repository.CommentRepository;
 import com.trip.tripshorts.member.domain.Member;
 import com.trip.tripshorts.member.repository.MemberRepository;
 import com.trip.tripshorts.video.domain.Video;
 import com.trip.tripshorts.video.repository.VideoRepository;
+import com.trip.tripshorts.video.service.S3Service;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class CommentService {
 
     private final MemberRepository memberRepository;
     private final VideoRepository videoRepository;
     private final CommentRepository commentRepository;
+    private final S3Service s3Service;
 
-    public void saveComment(String email, Long videoId, String content) {
-
-        // 유저 검색
-        Member member = memberRepository.findByEmail(email)
-                .orElseThrow(RuntimeException::new);
-
-        // 영상 검색
-        Video video = videoRepository.findById(videoId)
-                .orElseThrow(RuntimeException::new);
-
-        Comment comment = new Comment(content);
-
-        member.addComment(comment);
-        video.addComment(comment);
-
-        commentRepository.save(comment);
-    }
+    public List<CommentResponse> getCommentList(Long videoId) {
+        List<CommentResponse> comments = commentRepository.findAllByVideoId(videoId).
+                stream()
+                .map(comment -> {
+                    String presignedUrl = s3Service.generatePresignedUrlForDownload(comment.getMember().getImageUrl());
+                    return CommentResponse.from(comment, presignedUrl);
+                })
+                .toList();
+        log.debug("getComment service 정상 반응");
+        return comments;
+    };
 }

--- a/src/main/java/com/trip/tripshorts/comment/service/CommentService.java
+++ b/src/main/java/com/trip/tripshorts/comment/service/CommentService.java
@@ -36,4 +36,19 @@ public class CommentService {
         log.debug("getComment service 정상 반응");
         return comments;
     };
+
+    @Transactional
+    public void createComment(Long videoId, CommentRequest commentRequest) {
+        Member member = authService.getCurrentMember();
+        Video video = videoRepository.findById(videoId)
+                .orElseThrow(()-> new EntityNotFoundException("Video not found"));
+
+        Comment comment = Comment.builder()
+                .content(commentRequest.content())
+                .video(video)
+                .member(member)
+                .build();
+
+        commentRepository.save(comment);
+    }
 }

--- a/src/main/java/com/trip/tripshorts/comment/service/CommentService.java
+++ b/src/main/java/com/trip/tripshorts/comment/service/CommentService.java
@@ -1,6 +1,8 @@
 package com.trip.tripshorts.comment.service;
 
+import com.trip.tripshorts.auth.service.AuthService;
 import com.trip.tripshorts.comment.domain.Comment;
+import com.trip.tripshorts.comment.dto.CommentRequest;
 import com.trip.tripshorts.comment.dto.CommentResponse;
 import com.trip.tripshorts.comment.repository.CommentRepository;
 import com.trip.tripshorts.member.domain.Member;
@@ -8,9 +10,11 @@ import com.trip.tripshorts.member.repository.MemberRepository;
 import com.trip.tripshorts.video.domain.Video;
 import com.trip.tripshorts.video.repository.VideoRepository;
 import com.trip.tripshorts.video.service.S3Service;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -22,15 +26,12 @@ public class CommentService {
     private final MemberRepository memberRepository;
     private final VideoRepository videoRepository;
     private final CommentRepository commentRepository;
-    private final S3Service s3Service;
+    private final AuthService authService;
 
     public List<CommentResponse> getCommentList(Long videoId) {
-        List<CommentResponse> comments = commentRepository.findAllByVideoId(videoId).
+        List<CommentResponse> comments = commentRepository.findAllByVideoIdOrderByCreatedDateDesc(videoId).
                 stream()
-                .map(comment -> {
-                    String presignedUrl = s3Service.generatePresignedUrlForDownload(comment.getMember().getImageUrl());
-                    return CommentResponse.from(comment, presignedUrl);
-                })
+                .map(CommentResponse::from)
                 .toList();
         log.debug("getComment service 정상 반응");
         return comments;

--- a/src/main/java/com/trip/tripshorts/member/domain/Member.java
+++ b/src/main/java/com/trip/tripshorts/member/domain/Member.java
@@ -50,7 +50,6 @@ public class Member extends BaseTimeEntity {
 
     public void addComment(Comment comment) {
         comments.add(comment);
-        comment.setMember(this);
     }
 
     public void setImageUrl(String imageUrl) {

--- a/src/main/java/com/trip/tripshorts/video/domain/Video.java
+++ b/src/main/java/com/trip/tripshorts/video/domain/Video.java
@@ -43,6 +43,5 @@ public class Video extends BaseTimeEntity {
 
     public void addComment(Comment comment) {
         comments.add(comment);
-        comment.setVideo(this);
     }
 }


### PR DESCRIPTION
## 📌 구현 기능
- 댓글 작성 및 댓글 목록 불러오기 기능 추가

## 🔍 구현 내용
- Controller에 End point 추가
- 반환을 위한 CommentResponse DTO 생성
- Service에 댓글 목록 불러오는 메서드 추가
- Entity에서 Base Time Entity를 상속받아 작성 시간을 필드로 갖도록 수정
- 댓글 작성 기능 추가

## 🤔 고민한 부분
- 댓글 작성 시 response로 해당 댓글을 반환하여 프론트에서 처리 후 화면에 반영해야 하는지 고민했으나 댓글 작성 후 POST 요청을 한 뒤 GET 요청으로 댓글을 다시 한 번 불러오는 편이 낫다고 생각하여 Void 형식으로 반환하는 것으로 결정하였습니다.


## ✅ 테스트 결과
<img width="517" alt="image" src="https://github.com/user-attachments/assets/2c87ccb1-6a5f-45af-9d67-467db4bf0220">


## 📌 참고
- 우선적으로 댓글 작성 목록 순으로 반환하도록 하였으나, 추후 좋아요 순으로 반환하도록 수정할 필요가 있습니다.