### PR TITLE
feat: 좋아요 기능 구현

### DIFF
--- a/src/main/java/com/trip/tripshorts/good/controller/GoodController.java
+++ b/src/main/java/com/trip/tripshorts/good/controller/GoodController.java
@@ -1,0 +1,9 @@
+package com.trip.tripshorts.good.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RestController;
+
+@Controller
+@RestController("/api/v1/good")
+public class GoodController {
+}

--- a/src/main/java/com/trip/tripshorts/good/controller/GoodController.java
+++ b/src/main/java/com/trip/tripshorts/good/controller/GoodController.java
@@ -4,10 +4,7 @@ import com.trip.tripshorts.good.service.GoodService;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/goods")
@@ -19,8 +16,14 @@ public class GoodController {
     @PostMapping("/{videoId}/like")
     public ResponseEntity<Void> addGood(@PathVariable Long videoId) {
         log.debug("Adding good {}", videoId);
-        System.out.println("Adding good : "+ videoId);
         goodService.addGood(videoId);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{videoId}/like")
+    public ResponseEntity<Void> removeGood(@PathVariable Long videoId) {
+        log.debug("Removing good {}", videoId);
+        goodService.removeGood(videoId);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/trip/tripshorts/good/controller/GoodController.java
+++ b/src/main/java/com/trip/tripshorts/good/controller/GoodController.java
@@ -1,9 +1,26 @@
 package com.trip.tripshorts.good.controller;
 
-import org.springframework.stereotype.Controller;
+import com.trip.tripshorts.good.service.GoodService;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Controller
-@RestController("/api/v1/good")
+@RestController
+@RequestMapping("/api/v1/goods")
+@AllArgsConstructor
+@Slf4j
 public class GoodController {
+    private GoodService goodService;
+
+    @PostMapping("/{videoId}/like")
+    public ResponseEntity<Void> addGood(@PathVariable Long videoId) {
+        log.debug("Adding good {}", videoId);
+        System.out.println("Adding good : "+ videoId);
+        goodService.addGood(videoId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/trip/tripshorts/good/controller/GoodController.java
+++ b/src/main/java/com/trip/tripshorts/good/controller/GoodController.java
@@ -1,5 +1,6 @@
 package com.trip.tripshorts.good.controller;
 
+import com.trip.tripshorts.good.dto.GoodStatusResponse;
 import com.trip.tripshorts.good.service.GoodService;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,5 +26,12 @@ public class GoodController {
         log.debug("Removing good {}", videoId);
         goodService.removeGood(videoId);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/{videoId}/status")
+    public ResponseEntity<GoodStatusResponse> getGoodStatus(@PathVariable Long videoId) {
+        log.debug("Get good status {}", videoId);
+        GoodStatusResponse goodStatusResponse = goodService.getGoodStatus(videoId);
+        return ResponseEntity.ok(goodStatusResponse);
     }
 }

--- a/src/main/java/com/trip/tripshorts/good/domain/Good.java
+++ b/src/main/java/com/trip/tripshorts/good/domain/Good.java
@@ -3,19 +3,18 @@ package com.trip.tripshorts.good.domain;
 import com.trip.tripshorts.member.domain.Member;
 import com.trip.tripshorts.video.domain.Video;
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
 public class Good {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "good_id")
     private Long id;
-
-    private int count;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "video_id")
@@ -24,4 +23,16 @@ public class Good {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    public static Good createGood(){
+        return new Good();
+    }
+
+    public void setVideo(Video video) {
+        this.video = video;
+    }
+
+    public void setMember(Member member) {
+        this.member = member;
+    }
 }

--- a/src/main/java/com/trip/tripshorts/good/dto/GoodStatusResponse.java
+++ b/src/main/java/com/trip/tripshorts/good/dto/GoodStatusResponse.java
@@ -1,0 +1,11 @@
+package com.trip.tripshorts.good.dto;
+
+import lombok.*;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class GoodStatusResponse {
+    private boolean liked;
+    private long totalLikes;
+}

--- a/src/main/java/com/trip/tripshorts/good/repository/GoodRepository.java
+++ b/src/main/java/com/trip/tripshorts/good/repository/GoodRepository.java
@@ -1,0 +1,8 @@
+package com.trip.tripshorts.good.repository;
+
+import com.trip.tripshorts.good.domain.Good;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GoodRepository extends JpaRepository<Good, Long> {}

--- a/src/main/java/com/trip/tripshorts/good/repository/GoodRepository.java
+++ b/src/main/java/com/trip/tripshorts/good/repository/GoodRepository.java
@@ -11,4 +11,6 @@ import java.util.Optional;
 @Repository
 public interface GoodRepository extends JpaRepository<Good, Long> {
     Optional<Good> findByVideoAndMember(Video video, Member member);
+
+    boolean existsByVideoAndMember(Video video, Member member);
 }

--- a/src/main/java/com/trip/tripshorts/good/repository/GoodRepository.java
+++ b/src/main/java/com/trip/tripshorts/good/repository/GoodRepository.java
@@ -1,8 +1,14 @@
 package com.trip.tripshorts.good.repository;
 
 import com.trip.tripshorts.good.domain.Good;
+import com.trip.tripshorts.member.domain.Member;
+import com.trip.tripshorts.video.domain.Video;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
-public interface GoodRepository extends JpaRepository<Good, Long> {}
+public interface GoodRepository extends JpaRepository<Good, Long> {
+    Optional<Good> findByVideoAndMember(Video video, Member member);
+}

--- a/src/main/java/com/trip/tripshorts/good/service/GoodService.java
+++ b/src/main/java/com/trip/tripshorts/good/service/GoodService.java
@@ -35,4 +35,17 @@ public class GoodService {
         member.addLike(good);
         goodRepository.save(good);
     }
+
+    public void removeGood(Long videoId) {
+        Member member = authService.getCurrentMember();
+        Video video = videoRepository.findById(videoId)
+                .orElseThrow(EntityNotFoundException::new);
+
+        Good good = goodRepository.findByVideoAndMember(video, member)
+                .orElseThrow(EntityNotFoundException::new);
+
+        video.removeLike(good);
+        member.removeLike(good);
+        goodRepository.delete(good);
+    }
 }

--- a/src/main/java/com/trip/tripshorts/good/service/GoodService.java
+++ b/src/main/java/com/trip/tripshorts/good/service/GoodService.java
@@ -1,0 +1,7 @@
+package com.trip.tripshorts.good.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class GoodService {
+}

--- a/src/main/java/com/trip/tripshorts/good/service/GoodService.java
+++ b/src/main/java/com/trip/tripshorts/good/service/GoodService.java
@@ -1,7 +1,38 @@
 package com.trip.tripshorts.good.service;
 
+import com.trip.tripshorts.auth.service.AuthService;
+import com.trip.tripshorts.good.domain.Good;
+import com.trip.tripshorts.good.repository.GoodRepository;
+import com.trip.tripshorts.member.domain.Member;
+import com.trip.tripshorts.video.domain.Video;
+import com.trip.tripshorts.video.repository.VideoRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 @Service
+@RequiredArgsConstructor
 public class GoodService {
+    private final AuthService authService;
+    private final VideoRepository videoRepository;
+    private final GoodRepository goodRepository;
+
+    public void addGood(Long videoId) {
+        Member member = authService.getCurrentMember();
+        Video video = videoRepository.findById(videoId)
+                .orElseThrow(EntityNotFoundException::new);
+
+        Optional<Good> alreadyGood = goodRepository.findByVideoAndMember(video, member);
+        if (alreadyGood.isPresent()) {
+            throw new RuntimeException("이미 좋아요를 누른 영상입니다");
+        }
+
+        Good good = Good.createGood();
+
+        video.addLike(good);
+        member.addLike(good);
+        goodRepository.save(good);
+    }
 }

--- a/src/main/java/com/trip/tripshorts/good/service/GoodService.java
+++ b/src/main/java/com/trip/tripshorts/good/service/GoodService.java
@@ -2,6 +2,7 @@ package com.trip.tripshorts.good.service;
 
 import com.trip.tripshorts.auth.service.AuthService;
 import com.trip.tripshorts.good.domain.Good;
+import com.trip.tripshorts.good.dto.GoodStatusResponse;
 import com.trip.tripshorts.good.repository.GoodRepository;
 import com.trip.tripshorts.member.domain.Member;
 import com.trip.tripshorts.video.domain.Video;
@@ -9,6 +10,7 @@ import com.trip.tripshorts.video.repository.VideoRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -19,6 +21,7 @@ public class GoodService {
     private final VideoRepository videoRepository;
     private final GoodRepository goodRepository;
 
+    @Transactional
     public void addGood(Long videoId) {
         Member member = authService.getCurrentMember();
         Video video = videoRepository.findById(videoId)
@@ -36,6 +39,7 @@ public class GoodService {
         goodRepository.save(good);
     }
 
+    @Transactional
     public void removeGood(Long videoId) {
         Member member = authService.getCurrentMember();
         Video video = videoRepository.findById(videoId)
@@ -47,5 +51,18 @@ public class GoodService {
         video.removeLike(good);
         member.removeLike(good);
         goodRepository.delete(good);
+    }
+
+    @Transactional(readOnly = true)
+    public GoodStatusResponse getGoodStatus(Long videoId) {
+        Member member = authService.getCurrentMember();
+        Video video = videoRepository.findById(videoId)
+                .orElseThrow(EntityNotFoundException::new);
+
+        boolean liked = goodRepository.existsByVideoAndMember(video, member);
+        return GoodStatusResponse.builder()
+                .liked(liked)
+                .totalLikes(video.getLikes().size())
+                .build();
     }
 }

--- a/src/main/java/com/trip/tripshorts/member/domain/Member.java
+++ b/src/main/java/com/trip/tripshorts/member/domain/Member.java
@@ -59,4 +59,9 @@ public class Member extends BaseTimeEntity {
     public void setNickname(String nickname) {
         this.nickname = nickname;
     }
+
+    public void addLike(Good good) {
+        likes.add(good);
+        good.setMember(this);
+    }
 }

--- a/src/main/java/com/trip/tripshorts/member/domain/Member.java
+++ b/src/main/java/com/trip/tripshorts/member/domain/Member.java
@@ -64,4 +64,9 @@ public class Member extends BaseTimeEntity {
         likes.add(good);
         good.setMember(this);
     }
+
+    public void removeLike(Good good){
+        this.likes.remove(good);
+        good.setMember(null);
+    }
 }

--- a/src/main/java/com/trip/tripshorts/video/domain/Video.java
+++ b/src/main/java/com/trip/tripshorts/video/domain/Video.java
@@ -44,4 +44,9 @@ public class Video extends BaseTimeEntity {
     public void addComment(Comment comment) {
         comments.add(comment);
     }
+
+    public void addLike(Good good){
+        this.likes.add(good);
+        good.setVideo(this);
+    }
 }

--- a/src/main/java/com/trip/tripshorts/video/domain/Video.java
+++ b/src/main/java/com/trip/tripshorts/video/domain/Video.java
@@ -49,4 +49,9 @@ public class Video extends BaseTimeEntity {
         this.likes.add(good);
         good.setVideo(this);
     }
+
+    public void removeLike(Good good) {
+        this.likes.remove(good);
+        good.setMember(null);
+    }
 }


### PR DESCRIPTION
## 📌 구현 기능
- 비디오 좋아요 추가/제거 기능
- 양방향 연관관계를 통한 좋아요 데이터 관리
- 비디오 좋아요 상태 조회 기능

## 🔍 구현 내용
- GoodController에 좋아요 관련 API 엔드포인트 구현
- GoodService에 비즈니스 로직 구현
- Entity 간 양방향 연관관계 설정
 
## 🤔 고민한 부분
-  Video와 Member 모두에서 좋아요 목록관리가 필요한지 고민했으나 데이터 일관성 유지를 위해 필수적인 것을 알게 되었습니다.
- 동일한 유저가 같은 영상에 좋아요 추가 api를 두번 날아오는 경우를   방지하기 위해 중복으로 좋아요 요청이 올 경우를 방지하였습니다.
- Video Entity에 likeCount 필드를 추가하여 총 좋아요 수를 관리하는 것에 대해 고민했으나 서비스의 사이즈가 작기 때문에 우선 Like Listd의 size()를 이용하여 구현하여 직관적으로 보이도록 하였습니다. 

## ✅ 테스트 결과
<img width="137" alt="image" src="https://github.com/user-attachments/assets/591ccf86-e973-4651-ad27-e503d420159e">

- 정상적으로 데이터가 저장됨을 알 수 있습니다.


## 📌 참고
[양방향 연관관계](https://velog.io/@yuseogi0218/JPA-%EC%96%91%EB%B0%A9%ED%96%A5-%EC%97%B0%EA%B4%80%EA%B4%80%EA%B3%84)

[양방향 연관관계의 주의점과 편의 메서드](https://skatpdnjs.tistory.com/49)
