### PR TITLE
feat: myPage를 위한 API 및 사용자가 올린 영상 삭제 API 추가

### DIFF
--- a/src/main/java/com/trip/tripshorts/video/controller/VideoController.java
+++ b/src/main/java/com/trip/tripshorts/video/controller/VideoController.java
@@ -68,4 +68,14 @@ public class VideoController {
         return ResponseEntity.ok(videoService.getVideoPage(cursorId, size));
     }
 
+    @GetMapping("/my-videos")
+    public ResponseEntity<MyVideoPageResponse> getMyVideos(
+            @RequestParam(required = false) Long cursorId,
+            @RequestParam int size
+    ) {
+        MyVideoPageResponse myVideos = videoService.getMyVideos(cursorId, size);
+        log.debug("videos Size: {}", myVideos.getVideos().size());
+        return ResponseEntity.ok(myVideos);
+    }
+
 }

--- a/src/main/java/com/trip/tripshorts/video/controller/VideoController.java
+++ b/src/main/java/com/trip/tripshorts/video/controller/VideoController.java
@@ -82,8 +82,14 @@ public class VideoController {
     @GetMapping("/my-videos/feed")
     public ResponseEntity<VideoPageResponse> getMyVideoPages(
             @RequestParam(required = false) Long cursorId,
-            @RequestParam(defaultValue="6") int size
+            @RequestParam int size
     ){
         return ResponseEntity.ok(videoService.getMyVideoPages(cursorId, size));
+    }
+
+    @DeleteMapping("/my-videos/{videoId}")
+    public ResponseEntity<Void> deleteVideo(@PathVariable Long videoId) {
+        videoService.deleteVideo(videoId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/trip/tripshorts/video/controller/VideoController.java
+++ b/src/main/java/com/trip/tripshorts/video/controller/VideoController.java
@@ -78,4 +78,12 @@ public class VideoController {
         return ResponseEntity.ok(myVideos);
     }
 
+
+    @GetMapping("/my-videos/feed")
+    public ResponseEntity<VideoPageResponse> getMyVideoPages(
+            @RequestParam(required = false) Long cursorId,
+            @RequestParam(defaultValue="6") int size
+    ){
+        return ResponseEntity.ok(videoService.getMyVideoPages(cursorId, size));
+    }
 }

--- a/src/main/java/com/trip/tripshorts/video/dto/MyVideoListResponse.java
+++ b/src/main/java/com/trip/tripshorts/video/dto/MyVideoListResponse.java
@@ -1,0 +1,13 @@
+package com.trip.tripshorts.video.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MyVideoListResponse {
+    private Long videoId;
+    private String thumbnailUrl;
+    private String tourName;
+}

--- a/src/main/java/com/trip/tripshorts/video/dto/MyVideoPageResponse.java
+++ b/src/main/java/com/trip/tripshorts/video/dto/MyVideoPageResponse.java
@@ -1,0 +1,22 @@
+package com.trip.tripshorts.video.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class MyVideoPageResponse {
+    private final List<MyVideoListResponse> videos;
+    private final Long nextCursor;
+    private final boolean hasNext;
+
+    public static MyVideoPageResponse of(List<MyVideoListResponse> videos, Long lastVideoId, boolean hasNext) {
+        return MyVideoPageResponse.builder()
+                .videos(videos)
+                .nextCursor(hasNext ? lastVideoId : null)
+                .hasNext(hasNext)
+                .build();
+    }
+}

--- a/src/main/java/com/trip/tripshorts/video/dto/MyVideoPageResponse.java
+++ b/src/main/java/com/trip/tripshorts/video/dto/MyVideoPageResponse.java
@@ -8,12 +8,14 @@ import java.util.List;
 @Getter
 @Builder
 public class MyVideoPageResponse {
+    private final String nickname;
     private final List<MyVideoListResponse> videos;
     private final Long nextCursor;
     private final boolean hasNext;
 
-    public static MyVideoPageResponse of(List<MyVideoListResponse> videos, Long lastVideoId, boolean hasNext) {
+    public static MyVideoPageResponse of(String nickname, List<MyVideoListResponse> videos, Long lastVideoId, boolean hasNext) {
         return MyVideoPageResponse.builder()
+                .nickname(nickname)
                 .videos(videos)
                 .nextCursor(hasNext ? lastVideoId : null)
                 .hasNext(hasNext)

--- a/src/main/java/com/trip/tripshorts/video/repository/VideoRepository.java
+++ b/src/main/java/com/trip/tripshorts/video/repository/VideoRepository.java
@@ -43,4 +43,17 @@ public interface VideoRepository extends JpaRepository<Video, Long> {
             "ORDER BY v.id DESC " +
             "LIMIT :size")
     List<Video> findVideosByCursorId(@Param("cursorId") Long cursorId, @Param("size") int size);
+
+    @Query("SELECT DISTINCT v FROM Video v " +
+            "LEFT JOIN FETCH v.member m " +
+            "LEFT JOIN FETCH v.tour t " +  // Tour 정보도 필요하므로 추가
+            "WHERE v.member.id = :memberId " +
+            "AND (:cursorId IS NULL OR v.id < :cursorId) " +
+            "ORDER BY v.id DESC " +
+            "LIMIT :size")
+    List<Video> findMyVideosByCursor(
+            @Param("memberId") Long memberId,
+            @Param("cursorId") Long cursorId,
+            @Param("size") int size
+    );
 }

--- a/src/main/java/com/trip/tripshorts/video/service/VideoService.java
+++ b/src/main/java/com/trip/tripshorts/video/service/VideoService.java
@@ -198,6 +198,10 @@ public class VideoService {
             throw new IllegalArgumentException("Illegal User for this video: " + videoId);
         }
 
+        currentMember.getVideos().remove(video);
+        Tour tour = video.getTour();
+        tour.getVideos().remove(video);
+
         videoRepository.delete(video);
         return;
     }

--- a/src/main/java/com/trip/tripshorts/video/service/VideoService.java
+++ b/src/main/java/com/trip/tripshorts/video/service/VideoService.java
@@ -152,6 +152,7 @@ public class VideoService {
                 videoResponses.get(videoResponses.size() - 1).getVideoId();
 
         return MyVideoPageResponse.of(
+                currentMember.getNickname(),
                 videoResponses,
                 lastVideoId,
                 hasNext

--- a/src/main/java/com/trip/tripshorts/video/service/VideoService.java
+++ b/src/main/java/com/trip/tripshorts/video/service/VideoService.java
@@ -188,4 +188,17 @@ public class VideoService {
 
         return VideoPageResponse.of(videoResponses, lastVideoId, hasNext);
     }
+
+    public void deleteVideo(Long videoId) {
+        Member currentMember = authService.getCurrentMember();
+        Video video = videoRepository.findById(videoId)
+                .orElseThrow(() -> new IllegalArgumentException("Failed to find video with id: " + videoId));
+
+        if(!currentMember.equals(video.getMember())) {
+            throw new IllegalArgumentException("Illegal User for this video: " + videoId);
+        }
+
+        videoRepository.delete(video);
+        return;
+    }
 }

--- a/src/main/java/com/trip/tripshorts/video/service/VideoService.java
+++ b/src/main/java/com/trip/tripshorts/video/service/VideoService.java
@@ -126,4 +126,35 @@ public class VideoService {
 
         video.raiseView();
     }
+
+    public MyVideoPageResponse getMyVideos(Long cursorId, int size) {
+        Member currentMember = authService.getCurrentMember();
+
+        // size + 1로 다음 페이지 존재 여부 확인
+        List<Video> videos = videoRepository.findMyVideosByCursor(
+                currentMember.getId(),
+                cursorId,
+                size + 1
+        );
+
+        boolean hasNext = videos.size() > size;
+        List<Video> pagedVideos = hasNext ? videos.subList(0, size) : videos;
+
+        List<MyVideoListResponse> videoResponses = pagedVideos.stream()
+                .map(video -> MyVideoListResponse.builder()
+                        .videoId(video.getId())
+                        .thumbnailUrl(video.getThumbnailUrl())
+                        .tourName(video.getTour().getTitle())
+                        .build())
+                .toList();
+
+        Long lastVideoId = videoResponses.isEmpty() ? null :
+                videoResponses.get(videoResponses.size() - 1).getVideoId();
+
+        return MyVideoPageResponse.of(
+                videoResponses,
+                lastVideoId,
+                hasNext
+        );
+    }
 }


### PR DESCRIPTION
## 📌 구현 기능
myPage를 위한 API 및 사용자가 올린 영상 삭제 API 추가

## 🔍 구현 내용
- 특정 사용자가 올린 영상들만 반환 api 추가
- 특정 영상 삭제 api 추가
- 특정 사용자가 올린 영상들을 쇼츠로 보여주기 위한 cursorID 방식의 페이지네이션 추가

## 🤔 고민한 부분
- 처음에는 MyPage 요청이 왔을 때 videoURL 과 관련 정보들을 전부 반환해야 하나 고민했으나 로직 상 해당 페이지에서 썸네일을 클릭해서 넘어간 뒤에 필요하다고 생각하여 제외하였습니다. 

## ✅ 테스트 결과


## 📌 참고
- 현재 videoService 로직 내에서 반복적인 코드가 다소 존재하는데 추후 공통 부분들은 수정하면 좋을 것 같습니다. 