### PR TITLE
feat: 영상 업로드 시 GPT API를 활용한 태그 자동 생성 기능

### DIFF
--- a/src/main/java/com/trip/tripshorts/ai/config/RestTemplateConfig.java
+++ b/src/main/java/com/trip/tripshorts/ai/config/RestTemplateConfig.java
@@ -1,0 +1,22 @@
+package com.trip.tripshorts.ai.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        RestTemplate restTemplate = new RestTemplate();
+
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(5000);
+        factory.setReadTimeout(5000);
+
+        restTemplate.setRequestFactory(factory);
+        return restTemplate;
+    }
+}

--- a/src/main/java/com/trip/tripshorts/ai/dto/ChatChoice.java
+++ b/src/main/java/com/trip/tripshorts/ai/dto/ChatChoice.java
@@ -1,0 +1,4 @@
+package com.trip.tripshorts.ai.dto;
+
+public record ChatChoice(ChatMessage message) {
+}

--- a/src/main/java/com/trip/tripshorts/ai/dto/ChatGptRequest.java
+++ b/src/main/java/com/trip/tripshorts/ai/dto/ChatGptRequest.java
@@ -1,0 +1,6 @@
+package com.trip.tripshorts.ai.dto;
+
+import java.util.List;
+
+public record ChatGptRequest(String model, List<ChatMessage> messages, double temperature, int maxTokens) {
+}

--- a/src/main/java/com/trip/tripshorts/ai/dto/ChatGptRequest.java
+++ b/src/main/java/com/trip/tripshorts/ai/dto/ChatGptRequest.java
@@ -1,6 +1,13 @@
 package com.trip.tripshorts.ai.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.List;
 
-public record ChatGptRequest(String model, List<ChatMessage> messages, double temperature, int maxTokens) {
+public record ChatGptRequest(
+        String model,
+        List<ChatMessage> messages,
+        double temperature,
+        @JsonProperty("max_tokens")
+        int maxTokens) {
 }

--- a/src/main/java/com/trip/tripshorts/ai/dto/ChatGptResponse.java
+++ b/src/main/java/com/trip/tripshorts/ai/dto/ChatGptResponse.java
@@ -1,0 +1,6 @@
+package com.trip.tripshorts.ai.dto;
+
+import java.util.List;
+
+public record ChatGptResponse(List<ChatChoice> choices) {
+}

--- a/src/main/java/com/trip/tripshorts/ai/dto/ChatMessage.java
+++ b/src/main/java/com/trip/tripshorts/ai/dto/ChatMessage.java
@@ -1,0 +1,3 @@
+package com.trip.tripshorts.ai.dto;
+
+public record ChatMessage(String role, String content){}

--- a/src/main/java/com/trip/tripshorts/ai/dto/GeneratedTagsResponse.java
+++ b/src/main/java/com/trip/tripshorts/ai/dto/GeneratedTagsResponse.java
@@ -1,0 +1,8 @@
+package com.trip.tripshorts.ai.dto;
+
+import java.util.List;
+
+public record GeneratedTagsResponse(
+        List<String> tags
+) {
+}

--- a/src/main/java/com/trip/tripshorts/ai/dto/VideoTagRequest.java
+++ b/src/main/java/com/trip/tripshorts/ai/dto/VideoTagRequest.java
@@ -1,0 +1,4 @@
+package com.trip.tripshorts.ai.dto;
+
+public record VideoTagRequest(String location) {
+}

--- a/src/main/java/com/trip/tripshorts/ai/service/OpenAiService.java
+++ b/src/main/java/com/trip/tripshorts/ai/service/OpenAiService.java
@@ -1,0 +1,22 @@
+package com.trip.tripshorts.ai.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OpenAiService {
+
+    private static final String CHAT_URL = "https://api.openai.com/v1/chat/completions";
+    private final RestTemplate restTemplate;
+
+    @Value("${openai.api-key}")
+    private String apiKey;
+    @Value("${openai.model}")
+    private String model;
+
+}

--- a/src/main/java/com/trip/tripshorts/ai/service/OpenAiService.java
+++ b/src/main/java/com/trip/tripshorts/ai/service/OpenAiService.java
@@ -1,10 +1,18 @@
 package com.trip.tripshorts.ai.service;
 
+import com.trip.tripshorts.ai.dto.ChatGptRequest;
+import com.trip.tripshorts.ai.dto.ChatGptResponse;
+import com.trip.tripshorts.ai.dto.ChatMessage;
+import com.trip.tripshorts.ai.dto.GeneratedTagsResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
+
+import java.util.Arrays;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -18,5 +26,58 @@ public class OpenAiService {
     private String apiKey;
     @Value("${openai.model}")
     private String model;
+
+    public GeneratedTagsResponse generateTags(String location) {
+        ChatGptRequest request = createChatRequest(location);
+        ChatGptResponse response = callGptApi(request);
+
+        return parseTagsFromResponse(response);
+    }
+
+    private ChatGptRequest createChatRequest(String location) {
+        String prompt = String.format(
+                "다음 여행 장소와 관련된 인스타그램용 해시태그를 5개 생성해주세요. " +
+                        "각 태그는 '#' 없이 쉼표로 구분해서 반환해주세요. " +
+                        "장소: %s",
+                location
+        );
+
+        return new ChatGptRequest(
+                model,
+                List.of(new ChatMessage("user", prompt)),
+                0.7,
+                150
+        );
+    }
+
+    private ChatGptResponse callGptApi(ChatGptRequest request) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setBearerAuth(apiKey);
+
+        HttpEntity<ChatGptRequest> entity = new HttpEntity<>(request, headers);
+
+        try {
+            ResponseEntity<ChatGptResponse> response = restTemplate.exchange(
+                    "https://api.openai.com/v1/chat/completions",
+                    HttpMethod.POST,
+                    entity,
+                    ChatGptResponse.class
+            );
+            return response.getBody();
+        } catch (Exception e) {
+            log.error("GPT API 호출 실패", e);
+            throw new RuntimeException("태그 생성 실패", e);
+        }
+    }
+
+    private GeneratedTagsResponse parseTagsFromResponse(ChatGptResponse response) {
+        String content = response.choices().get(0).message().content();
+        List<String> tags = Arrays.stream(content.split(","))
+                .map(String::trim)
+                .filter(tag -> !tag.isEmpty())
+                .toList();
+        return new GeneratedTagsResponse(tags);
+    }
 
 }

--- a/src/main/java/com/trip/tripshorts/good/controller/GoodController.java
+++ b/src/main/java/com/trip/tripshorts/good/controller/GoodController.java
@@ -17,6 +17,7 @@ public class GoodController {
     @PostMapping("/{videoId}/like")
     public ResponseEntity<Void> addGood(@PathVariable Long videoId) {
         log.debug("Adding good {}", videoId);
+        System.out.println("좋아요 눌렀네요 ");
         goodService.addGood(videoId);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/trip/tripshorts/tag/domain/Tag.java
+++ b/src/main/java/com/trip/tripshorts/tag/domain/Tag.java
@@ -1,0 +1,28 @@
+package com.trip.tripshorts.tag.domain;
+
+import com.trip.tripshorts.video.domain.Video;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class Tag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "tag_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @ManyToOne(fetch=FetchType.LAZY)
+    @JoinColumn(name="video_id")
+    private Video video;
+
+    public void setVideo(Video video) {
+        this.video = video;
+    }
+}

--- a/src/main/java/com/trip/tripshorts/tag/repository/TagRepository.java
+++ b/src/main/java/com/trip/tripshorts/tag/repository/TagRepository.java
@@ -1,0 +1,7 @@
+package com.trip.tripshorts.tag.repository;
+
+import com.trip.tripshorts.tag.domain.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+}

--- a/src/main/java/com/trip/tripshorts/video/domain/Video.java
+++ b/src/main/java/com/trip/tripshorts/video/domain/Video.java
@@ -3,6 +3,7 @@ package com.trip.tripshorts.video.domain;
 import com.trip.tripshorts.comment.domain.Comment;
 import com.trip.tripshorts.good.domain.Good;
 import com.trip.tripshorts.member.domain.Member;
+import com.trip.tripshorts.tag.domain.Tag;
 import com.trip.tripshorts.tour.domain.Tour;
 import com.trip.tripshorts.util.BaseTimeEntity;
 import jakarta.persistence.*;
@@ -43,6 +44,19 @@ public class Video extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "tour_id")
     private Tour tour;
+
+    @OneToMany(mappedBy = "video", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Tag> tags = new ArrayList<>();
+
+    public void addTags(List<String> tagNames){
+        tagNames.forEach(tagName -> {
+            Tag tag = Tag.builder()
+                    .name(tagName)
+                    .video(this)
+                    .build();
+            this.tags.add(tag);
+        });
+    }
 
     public void addComment(Comment comment) {
         comments.add(comment);

--- a/src/main/java/com/trip/tripshorts/video/repository/VideoRepository.java
+++ b/src/main/java/com/trip/tripshorts/video/repository/VideoRepository.java
@@ -48,8 +48,8 @@ public interface VideoRepository extends JpaRepository<Video, Long> {
             "LEFT JOIN FETCH v.member m " +
             "LEFT JOIN FETCH v.tour t " +
             "WHERE v.member.id = :memberId " +
-            "AND (:cursorId IS NULL OR v.id < :cursorId) " +  // 변경: < 에서 > 로
-            "ORDER BY v.id DESC " +  // DESC 유지
+            "AND (:cursorId IS NULL OR v.id < :cursorId) " +
+            "ORDER BY v.id DESC " +
             "LIMIT :size")
     List<Video> findMyVideosByCursor(
             @Param("memberId") Long memberId,

--- a/src/main/java/com/trip/tripshorts/video/service/VideoService.java
+++ b/src/main/java/com/trip/tripshorts/video/service/VideoService.java
@@ -162,7 +162,6 @@ public class VideoService {
     public VideoPageResponse getMyVideoPages(Long cursorId, Long initialVideoId, int size) {
         Member currentMember = authService.getCurrentMember();
 
-        // initialVideoId가 있으면 더 큰 ID부터 가져오도록 수정
         if(initialVideoId != null && cursorId == null){
             cursorId = initialVideoId+1;  // 변경
         }


### PR DESCRIPTION
## 📌 구현 기능
- 영상 업로드 시 GPT API를 활용한 태그 자동 생성 기능

## 🔍 구현 내용
- Tag 도메인 추가 및 Video 도메인과의 양방향 연관관계 매핑
  - Video 엔티티에 tags 필드 추가 (1:N 관계)
- OpenAI GPT API 연동을 통한 태그 자동 생성
  - 관광지 이름을 기반으로 관련 태그 5개 자동 생성
  - GPT API 통신을 위한 DTO 클래스 구현
  - RestTemplate을 활용한 API 호출 로직 구현
- VideoService에 태그 생성 로직 통합
  - 비디오 생성 시 자동으로 태그 생성 및 연결
  - 트랜잭션 처리를 통한 데이터 일관성 보장
   
## 🤔 고민한 부분
- 태그 생성 시 다른 정보도 포함할 지 고민했으나 추후 프론트엔드 로직과 맞춰 수정하기로 하고 우선 TourName만 받아 생성하도록 구현하였습니다.

## ✅ 테스트 결과
- 태그 자동 생성 및 저장 성공
- GPT API 연동 정상 작동 확인
- Video-Tag 양방향 연관관계 정상 동작 확인

## 📌 참고
- 추후 태그 관련 정보들을 어떻게 활용할 지 고민해봐야 할 것 같습니다. 
[OpenAI API Documnet](https://velog.io/@euisuk-chung/%EC%A0%95%EB%A6%AC-OpenAI-API-Document)
[Spring Boot-RestTemplate 사용하기](https://m.blog.naver.com/seek316/223334925643)
