### PR TITLE
refactor: JWT 필터 관련 로직 수정

### DIFF
--- a/src/main/java/com/trip/tripshorts/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/trip/tripshorts/auth/JwtAuthenticationFilter.java
@@ -54,10 +54,4 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         filterChain.doFilter(request, response);
     }
-
-    @Override
-    protected boolean shouldNotFilter(HttpServletRequest request) {
-        String path = request.getServletPath();
-        return path.startsWith("/login"); // /login으로 시작하는 모든 경로 제외
-    }
 }

--- a/src/main/java/com/trip/tripshorts/auth/JwtTokenProvider.java
+++ b/src/main/java/com/trip/tripshorts/auth/JwtTokenProvider.java
@@ -6,7 +6,9 @@ import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 import java.util.Base64;
 import java.util.Date;
@@ -15,9 +17,12 @@ import java.util.Date;
 @RequiredArgsConstructor
 public class JwtTokenProvider {
 
-    private String secretKey = "tokensecretkeytokensecretkeytokensecretkeytokensecretkeytokensecretkey";
-    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30; // 30분
+    @Value("${jwt.secret-key}")
+    private String secretKey;
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60; // 60분
     private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7; // 7일
+    private static final String TOKEN_PREFIX = "Bearer ";
+    private static final String AUTHORIZATION_HEADER = "Authorization";
 
     @PostConstruct
     protected void init() {
@@ -56,8 +61,10 @@ public class JwtTokenProvider {
     }
 
     public String resolveAccessToken(HttpServletRequest request) {
-        if(request.getHeader("authorization") != null )
-            return request.getHeader("authorization").substring(7);
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(TOKEN_PREFIX)) {
+            return bearerToken.substring(TOKEN_PREFIX.length());
+        }
         return null;
     }
 

--- a/src/main/java/com/trip/tripshorts/auth/dto/KakaoUserInfo.java
+++ b/src/main/java/com/trip/tripshorts/auth/dto/KakaoUserInfo.java
@@ -1,0 +1,12 @@
+package com.trip.tripshorts.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class KakaoUserInfo {
+    private final String email;
+    private final String nickname;
+    private final String imageUrl;
+}


### PR DESCRIPTION

## 🔍 구현 내용
<!-- 구체적인 구현 내용을 적어주세요 -->
- jwt 생성을 위한 key 값 yml 파일에 저장
- 헤더에서 accessToken 값 추출 로직 수정
- 회원 정보를 가져오는 과정에서 `KakaoUserInfo` 를 생성하고  `createNewMember` 메서드를 통해 불필요한 로직을 제거