### PR TITLE
refactor: 비디오 조회 로직 수정

### DIFF
--- a/src/main/java/com/trip/tripshorts/video/controller/VideoController.java
+++ b/src/main/java/com/trip/tripshorts/video/controller/VideoController.java
@@ -61,13 +61,15 @@ public class VideoController {
         return ResponseEntity.ok(videoService.getVideoPage(sortBy, cursorId, size));
     }
 
-    @GetMapping("/feed/next")
+    @GetMapping("/feed/{direction}")
     public ResponseEntity<List<VideoResponse>> getNextVideoPages(
+            @PathVariable("direction") String direction,
             @RequestParam("sortby") String sortBy,
             @RequestParam("cursorid") Long cursorId,
             @RequestParam(required = false, defaultValue = "2") int size
     ){
-        return ResponseEntity.ok(videoService.getNextVideopage(sortBy, cursorId, size));
+
+        return ResponseEntity.ok(videoService.getMoreVideopage(direction, sortBy, cursorId, size));
     }
 
     @GetMapping("/my-videos")


### PR DESCRIPTION
## 📌 구현 기능
<!-- 구현한 기능을 적어주세요 -->
- 위로 스크롤할 경우의 동영상 조회를 할 수 있도록 구현했습니다.


## 🔍 구현 내용
<!-- 구체적인 구현 내용을 적어주세요 -->
- `direction` 을 `@Pathvariable` 을 통해 받아서 스크롤 방향에 대한 분기처리를 진행하였습니다.


## 🤔 고민한 부분
<!-- 구현 과정에서 고민했던 부분이나 어려웠던 부분을 적어주세요 -->
- 프론트에서 동영상을 시청할수록 계속해서 데이터가 쌓이는 부분이 메모리적으로 안좋다고 생각했고 이를 해결하기 위해서 이전 동영상을 더 조회할 수 있는 로직을 추가했습니다.